### PR TITLE
Collect include directories with *.hpp files in CMakeLists.txt.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,9 @@ endif()
 
 #finally, find sources and includes of the application, and create a target.
 RECURSIVE_FIND_DIR(INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/${CODAL_APP_SOURCE_DIR}" "*.h")
+RECURSIVE_FIND_DIR(HPP_DIRS "${PROJECT_SOURCE_DIR}/${CODAL_APP_SOURCE_DIR}" "*.hpp")
+list(APPEND INCLUDE_DIRS ${HPP_DIRS})
+
 # *.c?? only catches .cpp, not .c, so let's be precise
 RECURSIVE_FIND_FILE(SOURCE_FILES "${PROJECT_SOURCE_DIR}/${CODAL_APP_SOURCE_DIR}" "*.cpp")
 


### PR DESCRIPTION
To get this branch to build:

```
rm -r source/uTensor/
git clone https://github.com/uTensor/uTensor.git source/uTensor
rm -r source/uTensor/python
rm -r source/uTensor/tutorials
rm -r source/uTensor/TESTS
rm -r source/uTensor/tanh_model
```

Then we need to add the `#include <cstddef>` include to the `source/uTensor/src/uTensor/core/types.hpp` file.

And  after that a normal `python build.py` should work (with some warnings).